### PR TITLE
[FIX] Tick crash

### DIFF
--- a/src/main/java/cope/cosmos/util/Wrapper.java
+++ b/src/main/java/cope/cosmos/util/Wrapper.java
@@ -8,7 +8,7 @@ public interface Wrapper {
 	Minecraft mc = Minecraft.getMinecraft();
 
 	default boolean nullCheck() {
-		return mc.player != null || mc.world != null;
+		return mc.player != null && mc.world != null;
 	}
 
 	default Cosmos getCosmos() {


### PR DESCRIPTION
Used to crash when loading into a world with ElytraFlight etc, because it only checks whether either the player **or** world is not null.